### PR TITLE
docs: fix semantic-release integration (GitLab → GitHub)

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ chore: update dependencies
 
 ### Releases
 
-Automated releases via `semantic-release` with GitLab integration. Run `npm run release` to publish.
+Automated releases via `semantic-release` with GitHub integration. Run `npm run release` to publish.
 
 ## VSCode Setup
 


### PR DESCRIPTION
## Summary
This PR updates the README.md to accurately reflect the current state of the codebase.

## Changes
- Fixed semantic-release integration reference (GitLab → GitHub) to match actual repository host at github.com/yongchenglow/yongchenglow.com

## Testing
Documentation reviewed against actual codebase implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)