### PR TITLE
ci: add type-check job to reusable build workflow

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -62,6 +62,29 @@ jobs:
       - name: Run lint
         run: bun run lint
 
+  type-check:
+    name: type-check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: setup
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ inputs.bun_version }}
+
+      - name: Restore node_modules cache
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
+      - name: Run type check
+        run: bun run typecheck
+
   test:
     name: Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

`.github/renovate.json` declares a required status check that no workflow ever produces:

```json
"requiredStatusChecks": ["build", "lint", "test", "type-check"]
```

`.github/workflows/reusable-build.yml` defines `setup`, `lint`, `test`, `knip` (named "Dependency Check") and `security-scan` — but there is no `type-check` job. Because the check is never reported, Renovate's automerge gate waits on a status that can never arrive, and TypeScript errors can land without ever being caught in CI.

## Fix

Adds a `type-check` job to `reusable-build.yml` that mirrors the existing `lint` job exactly:

- same `actions/checkout@v6`
- same `oven-sh/setup-bun@v2` with the caller-supplied `bun_version`
- same `actions/cache@v5` `node_modules` restore keyed on `bun.lock`
- same `needs: setup`, `runs-on: ubuntu-latest`, `timeout-minutes: 10`

The step runs `bun run typecheck` (`tsc --noEmit`), a script that already exists in `package.json`.

## Status check name

Both the job key and `name:` are `type-check`, so the reported check name matches what `renovate.json` expects. No other job's name or behaviour was changed.

## Wiring

No changes needed in `ci.yml`. It consumes the reusable workflow wholesale via `uses:`, and the downstream `docker` job already has `needs: build`, so the new job is gated into the existing chain automatically. There is no aggregate gate job to update.

## Validation

- `actionlint .github/workflows/reusable-build.yml` — clean
- `bun run typecheck` — passes locally with no errors

(`actionlint` reports a pre-existing SC2086 info-level warning on `ci.yml:22`, unrelated to this change and left untouched.)

The new `type-check` job runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)