### PR TITLE
fix: harden og image endpoint and mermaid renderer

### DIFF
--- a/src/app/og/route.tsx
+++ b/src/app/og/route.tsx
@@ -4,21 +4,39 @@ import { SITE_AUTHOR } from "@/src/config/site";
 
 export const runtime = "edge";
 
+const MAX_TITLE_LENGTH = 200;
+const MAX_TAGS = 6;
+const MAX_TAG_LENGTH = 32;
+const AVATAR_FETCH_TIMEOUT_MS = 3000;
+
 export const GET = async (request: NextRequest) => {
 	const { searchParams } = new URL(request.url);
-	const title = searchParams.get("title") ?? SITE_AUTHOR.name;
+	const title = (searchParams.get("title") ?? SITE_AUTHOR.name).slice(
+		0,
+		MAX_TITLE_LENGTH,
+	);
 	const tagsParam = searchParams.get("tags") ?? "";
 	const tags = tagsParam
 		.split(",")
-		.map((t) => t.trim())
-		.filter(Boolean);
+		.map((t) => t.trim().slice(0, MAX_TAG_LENGTH))
+		.filter(Boolean)
+		.slice(0, MAX_TAGS);
 
 	const avatarUrl = new URL(SITE_AUTHOR.image, request.url).toString();
-	const avatarArrayBuffer = await fetch(avatarUrl).then((res) =>
-		res.arrayBuffer(),
-	);
-	const avatarBase64 = Buffer.from(avatarArrayBuffer).toString("base64");
-	const avatarSrc = `data:image/jpeg;base64,${avatarBase64}`;
+	let avatarSrc: string | null = null;
+	try {
+		const response = await fetch(avatarUrl, {
+			signal: AbortSignal.timeout(AVATAR_FETCH_TIMEOUT_MS),
+		});
+		if (response.ok) {
+			const avatarBase64 = Buffer.from(await response.arrayBuffer()).toString(
+				"base64",
+			);
+			avatarSrc = `data:image/jpeg;base64,${avatarBase64}`;
+		}
+	} catch {
+		// Avatar is decorative: render the card without it rather than failing.
+	}
 
 	return new ImageResponse(
 		<div
@@ -33,26 +51,28 @@ export const GET = async (request: NextRequest) => {
 			}}
 		>
 			{/* Avatar */}
-			<div
-				style={{
-					width: "140px",
-					height: "140px",
-					borderRadius: "70px",
-					overflow: "hidden",
-					flexShrink: 0,
-					marginRight: "48px",
-					border: "3px solid #334155",
-				}}
-			>
-				{/* biome-ignore lint/performance/noImgElement: next/image cannot be used inside ImageResponse (Satori edge runtime) */}
-				<img
-					src={avatarSrc}
-					width={140}
-					height={140}
-					style={{ objectFit: "cover" }}
-					alt=""
-				/>
-			</div>
+			{avatarSrc && (
+				<div
+					style={{
+						width: "140px",
+						height: "140px",
+						borderRadius: "70px",
+						overflow: "hidden",
+						flexShrink: 0,
+						marginRight: "48px",
+						border: "3px solid #334155",
+					}}
+				>
+					{/* biome-ignore lint/performance/noImgElement: next/image cannot be used inside ImageResponse (Satori edge runtime) */}
+					<img
+						src={avatarSrc}
+						width={140}
+						height={140}
+						style={{ objectFit: "cover" }}
+						alt=""
+					/>
+				</div>
+			)}
 
 			{/* Text content */}
 			<div
@@ -110,6 +130,9 @@ export const GET = async (request: NextRequest) => {
 		{
 			width: 1200,
 			height: 630,
+			headers: {
+				"Cache-Control": "public, max-age=3600, immutable",
+			},
 		},
 	);
 };

--- a/src/components/mdx/MermaidDiagram.tsx
+++ b/src/components/mdx/MermaidDiagram.tsx
@@ -28,7 +28,7 @@ export const MermaidDiagram = ({
 				mermaid.initialize({
 					startOnLoad: false,
 					theme: resolvedTheme === "dark" ? "dark" : "default",
-					securityLevel: "loose",
+					securityLevel: "strict",
 					fontFamily: "inherit",
 				});
 
@@ -42,7 +42,10 @@ export const MermaidDiagram = ({
 			} catch (err) {
 				if (mounted && containerRef.current) {
 					const message = err instanceof Error ? err.message : String(err);
-					containerRef.current.innerHTML = `<pre class="text-destructive whitespace-pre-wrap">${message}</pre>`;
+					const pre = document.createElement("pre");
+					pre.className = "text-destructive whitespace-pre-wrap";
+					pre.textContent = message;
+					containerRef.current.replaceChildren(pre);
 					setIsLoading(false);
 				}
 			}


### PR DESCRIPTION
## Summary

Hardening pass over the public `/og` image endpoint and the Mermaid renderer.

**Scope note, up front:** there is **no SSRF and no XSS being fixed here.** The avatar URL is built from `SITE_AUTHOR.image` resolved against the request's own origin, so it is not attacker-controlled — no allowlisting was added or needed. Satori escapes JSX text, so `title` and `tags` were never an injection vector — no HTML escaping was added. This PR is **DoS-resistance and defense-in-depth**, not a vulnerability fix.

## `src/app/og/route.tsx`

`/og` is public, unauthenticated, and previously uncached, which made it a cheap CPU amplification target — every request re-fetched the avatar and re-rendered a 1200x630 image.

- **Input clamping.** `title` is truncated to 200 characters and `tags` are capped at 6 entries of 32 characters each. Truncation rather than rejection, so existing callers keep working.
- **Fetch timeout.** The avatar `fetch` now uses `AbortSignal.timeout(3000)`. Previously a slow or hanging upstream would hold an edge invocation open indefinitely.
- **Graceful degradation.** A failed, non-OK, or timed-out avatar fetch now renders the card without the avatar instead of throwing a 500. The avatar block is conditional on the fetch succeeding.
- **Cache headers.** `Cache-Control: public, max-age=3600, immutable` on the `ImageResponse`, so repeat requests for the same card no longer re-do the fetch and render.

## `src/components/mdx/MermaidDiagram.tsx`

- **`securityLevel: "loose"` -> `"strict"`.** `loose` permits click handlers and raw HTML in diagram labels.
- **Error path.** The caught error `message` was interpolated straight into `innerHTML`. It now builds a `<pre>` and sets `textContent`, attached via `replaceChildren`. Styling and behavior are unchanged.

### Is `"strict"` safe for existing content?

Yes, and trivially so: **there are currently no mermaid diagrams in the repo at all.** A case-insensitive grep for `mermaid` across `content/` returns zero hits across all six `content/blog/*.mdx` files. The component is wired up in `MDXComponents.tsx` and ready for future diagrams, but nothing today renders through it, so nothing can be relying on click handlers or HTML labels. `strict` is the right default going forward.

## Verification

- `bun run tsc` — clean
- `bun run check` — clean (142 files, no fixes applied)
- `bun run knip` — clean
- `bun run build` — succeeds; `/og` compiles as a dynamic route and all MDX pages prerender
- `bun test` — 109 pass, 1 fail. The failure is `getAllPostYears > returns unique years in descending order`, which is **pre-existing and unrelated**: it lives in `src/lib/blog.ts` (owned by a separate PR, untouched here) and I confirmed it fails identically on a stashed clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)