### PR TITLE
fix: validate blog frontmatter and slugs at parse time

### DIFF
--- a/src/content/schema.ts
+++ b/src/content/schema.ts
@@ -122,13 +122,27 @@ export const AuthorSchema = z.object({
 	image: z.string(),
 });
 
+/**
+ * A YAML date field, normalized to an ISO 8601 date string (`YYYY-MM-DD`).
+ *
+ * YAML parses an unquoted `date: 2024-01-01` into a JS `Date` but a quoted
+ * `date: "2024-01-01"` into a string. Both are legitimate frontmatter, so the
+ * `Date` form is coerced here rather than rejected — otherwise authors get a
+ * build failure for forgetting quotes.
+ */
+const FrontmatterDateSchema = z
+	.union([z.string(), z.date()])
+	.transform((value) =>
+		value instanceof Date ? value.toISOString().slice(0, 10) : value,
+	);
+
 // Blog post frontmatter schema
 export const BlogFrontmatterSchema = z.object({
 	title: z.string(),
 	subtitle: z.string().optional(),
 	description: z.string(),
-	date: z.string(), // ISO 8601 format
-	lastUpdated: z.string().optional(),
+	date: FrontmatterDateSchema, // ISO 8601 format
+	lastUpdated: FrontmatterDateSchema.optional(),
 	author: z.string(),
 	tags: z.array(z.string()).optional(),
 	image: z.string().optional(),

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -4,23 +4,87 @@ import matter from "gray-matter";
 import { cache } from "react";
 import readingTime from "reading-time";
 import { BLOG_CATEGORIES, BLOG_CONFIG } from "@/src/config/blog";
-import type {
-	BlogFrontmatter,
-	BlogPost,
-	Category,
-	PaginationResult,
-} from "@/src/types/blog";
+import { BlogFrontmatterSchema } from "@/src/content/schema";
+import type { BlogPost, Category, PaginationResult } from "@/src/types/blog";
 
 const BLOG_CONTENT_PATH = path.join(process.cwd(), "content/blog");
 
+/**
+ * Slugs map directly onto filenames under `content/blog`, so anything outside
+ * this alphabet (path separators, `..`, URL escapes) must never reach
+ * `path.join`.
+ */
+const SLUG_PATTERN = /^[a-z0-9-]+$/;
+
+/** Thrown when a slug is well-formed but no matching content file exists. */
+export class BlogPostNotFoundError extends Error {
+	readonly slug: string;
+
+	constructor(slug: string) {
+		super(`Blog post not found: "${slug}"`);
+		this.name = "BlogPostNotFoundError";
+		this.slug = slug;
+	}
+}
+
+/** Thrown when a slug could not safely be turned into a content file path. */
+export class InvalidBlogSlugError extends Error {
+	readonly slug: string;
+
+	constructor(slug: string) {
+		super(
+			`Invalid blog slug: "${slug}". Slugs must match ${SLUG_PATTERN.source}.`,
+		);
+		this.name = "InvalidBlogSlugError";
+		this.slug = slug;
+	}
+}
+
+/**
+ * Thrown when a post's frontmatter does not satisfy `BlogFrontmatterSchema`.
+ * Content errors must fail loudly at build time rather than surfacing as a
+ * confusing render crash deep in a component.
+ */
+export class BlogFrontmatterError extends Error {
+	readonly slug: string;
+
+	constructor(slug: string, file: string, issues: string) {
+		super(`Invalid frontmatter in ${file}:\n${issues}`);
+		this.name = "BlogFrontmatterError";
+		this.slug = slug;
+	}
+}
+
+const assertValidSlug = (slug: string): void => {
+	if (!SLUG_PATTERN.test(slug)) throw new InvalidBlogSlugError(slug);
+};
+
 const parsePost = (slug: string): BlogPost => {
+	assertValidSlug(slug);
+
 	const mdxPath = path.join(BLOG_CONTENT_PATH, `${slug}.mdx`);
 	const mdPath = path.join(BLOG_CONTENT_PATH, `${slug}.md`);
-	const fullPath = fs.existsSync(mdxPath) ? mdxPath : mdPath;
+
+	let fullPath: string;
+	if (fs.existsSync(mdxPath)) fullPath = mdxPath;
+	else if (fs.existsSync(mdPath)) fullPath = mdPath;
+	else throw new BlogPostNotFoundError(slug);
+
 	const fileContents = fs.readFileSync(fullPath, "utf8");
 
 	const { data, content } = matter(fileContents);
-	const frontmatter = data as BlogFrontmatter;
+
+	const parsed = BlogFrontmatterSchema.safeParse(data);
+	if (!parsed.success) {
+		const issues = parsed.error.issues
+			.map((issue) => {
+				const at = issue.path.length > 0 ? issue.path.join(".") : "(root)";
+				return `  - ${at}: ${issue.message}`;
+			})
+			.join("\n");
+		throw new BlogFrontmatterError(slug, fullPath, issues);
+	}
+	const frontmatter = parsed.data;
 
 	// Calculate reading time
 	const { text: readingTimeText } = readingTime(content);

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -1,16 +1,11 @@
-export interface BlogFrontmatter {
-	title: string;
-	subtitle?: string;
-	description: string;
-	date: string; // ISO 8601 format
-	lastUpdated?: string;
-	author: string;
-	tags?: string[];
-	image?: string;
-	draft?: boolean;
-	featured?: boolean;
-	adsSlotId?: string;
-}
+import type { z } from "zod";
+import type { BlogFrontmatterSchema } from "@/src/content/schema";
+
+/**
+ * Derived from `BlogFrontmatterSchema` so the runtime validation and the
+ * compile-time type cannot drift apart.
+ */
+type BlogFrontmatter = z.infer<typeof BlogFrontmatterSchema>;
 
 export interface BlogPost {
 	slug: string;

--- a/test/lib/blog.test.ts
+++ b/test/lib/blog.test.ts
@@ -23,6 +23,9 @@ mock.module("node:path", () => {
 });
 
 const {
+	BlogFrontmatterError,
+	BlogPostNotFoundError,
+	InvalidBlogSlugError,
 	getAllBlogPosts,
 	getAllBlogSlugs,
 	getAllPostYears,
@@ -90,7 +93,7 @@ describe("getAllBlogSlugs", () => {
 describe("getAllBlogPosts", () => {
 	beforeEach(() => {
 		vi.mocked(fs.readdirSync).mockReturnValue(["old.mdx", "new.mdx"] as never);
-		vi.mocked(fs.existsSync).mockReturnValue(false);
+		vi.mocked(fs.existsSync).mockReturnValue(true);
 		vi.mocked(fs.readFileSync).mockImplementation((filePath: unknown) => {
 			if (String(filePath).includes("new"))
 				return mockPost("new", { date: "2024-06-01" });
@@ -135,7 +138,7 @@ describe("getFeaturedPost", () => {
 			"a.mdx",
 			"featured.mdx",
 		] as never);
-		vi.mocked(fs.existsSync).mockReturnValue(false);
+		vi.mocked(fs.existsSync).mockReturnValue(true);
 		vi.mocked(fs.readFileSync).mockImplementation((filePath: unknown) => {
 			if (String(filePath).includes("featured"))
 				return mockPost("featured", { date: "2024-01-01", featured: true });
@@ -146,7 +149,7 @@ describe("getFeaturedPost", () => {
 
 	it("falls back to the first (most recent) post when no featured post exists", () => {
 		vi.mocked(fs.readdirSync).mockReturnValue(["old.mdx", "new.mdx"] as never);
-		vi.mocked(fs.existsSync).mockReturnValue(false);
+		vi.mocked(fs.existsSync).mockReturnValue(true);
 		vi.mocked(fs.readFileSync).mockImplementation((filePath: unknown) => {
 			if (String(filePath).includes("new"))
 				return mockPost("new", { date: "2024-06-01" });
@@ -164,10 +167,10 @@ describe("getFeaturedPost", () => {
 describe("getBlogPostsByTag", () => {
 	beforeEach(() => {
 		vi.mocked(fs.readdirSync).mockReturnValue(["a.mdx", "b.mdx"] as never);
-		vi.mocked(fs.existsSync).mockReturnValue(false);
+		vi.mocked(fs.existsSync).mockReturnValue(true);
 		vi.mocked(fs.readFileSync).mockImplementation((filePath: unknown) => {
 			// Match on the filename only: the repo path itself may contain "/a".
-			if (String(filePath).endsWith("/a.md"))
+			if (String(filePath).endsWith("/a.mdx"))
 				return mockPost("a", { date: "2024-01-01", tags: "react, typescript" });
 			return mockPost("b", { date: "2023-01-01", tags: "vue" });
 		});
@@ -190,7 +193,7 @@ describe("getBlogPostNavigation", () => {
 			"middle.mdx",
 			"oldest.mdx",
 		] as never);
-		vi.mocked(fs.existsSync).mockReturnValue(false);
+		vi.mocked(fs.existsSync).mockReturnValue(true);
 		vi.mocked(fs.readFileSync).mockImplementation((filePath: unknown) => {
 			if (String(filePath).includes("newest"))
 				return mockPost("newest", { date: "2024-03-01" });
@@ -224,12 +227,12 @@ describe("getAllPostYears", () => {
 			"b.mdx",
 			"c.mdx",
 		] as never);
-		vi.mocked(fs.existsSync).mockReturnValue(false);
+		vi.mocked(fs.existsSync).mockReturnValue(true);
 		vi.mocked(fs.readFileSync).mockImplementation((filePath: unknown) => {
 			// Match on the filename only: the repo path itself may contain "/a".
-			if (String(filePath).endsWith("/a.md"))
+			if (String(filePath).endsWith("/a.mdx"))
 				return mockPost("a", { date: "2024-05-01" });
-			if (String(filePath).endsWith("/b.md"))
+			if (String(filePath).endsWith("/b.mdx"))
 				return mockPost("b", { date: "2023-05-01" });
 			return mockPost("c", { date: "2024-11-01" });
 		});
@@ -243,7 +246,7 @@ describe("getBlogPostsByYear", () => {
 			"y2024.mdx",
 			"y2023.mdx",
 		] as never);
-		vi.mocked(fs.existsSync).mockReturnValue(false);
+		vi.mocked(fs.existsSync).mockReturnValue(true);
 		vi.mocked(fs.readFileSync).mockImplementation((filePath: unknown) => {
 			if (String(filePath).includes("y2024"))
 				return mockPost("y2024", { date: "2024-06-01" });
@@ -262,7 +265,7 @@ describe("getBlogPostsByYear", () => {
 
 describe("getBlogPost", () => {
 	it("returns a BlogPost with the correct slug", () => {
-		vi.mocked(fs.existsSync).mockReturnValue(false);
+		vi.mocked(fs.existsSync).mockReturnValue(true);
 		vi.mocked(fs.readFileSync).mockReturnValue(
 			mockPost("test-slug", { date: "2024-01-01" }),
 		);
@@ -281,17 +284,22 @@ describe("getBlogPost", () => {
 	});
 
 	it("falls back to .md file when .mdx does not exist", () => {
-		vi.mocked(fs.existsSync).mockReturnValue(false);
+		vi.mocked(fs.existsSync).mockImplementation((filePath: unknown) =>
+			String(filePath).endsWith(".md"),
+		);
 		vi.mocked(fs.readFileSync).mockReturnValue(
 			mockPost("md-post", { date: "2024-01-01" }),
 		);
 		const post = getBlogPost("md-post");
 		expect(post.slug).toBe("md-post");
+		expect(vi.mocked(fs.readFileSync).mock.calls.at(-1)?.[0]).toStrictEqual(
+			expect.stringContaining("md-post.md"),
+		);
 	});
 
 	it("truncates excerpt to 200 characters", () => {
 		const longContent = "A".repeat(300);
-		vi.mocked(fs.existsSync).mockReturnValue(false);
+		vi.mocked(fs.existsSync).mockReturnValue(true);
 		vi.mocked(fs.readFileSync).mockReturnValue(
 			`---\ntitle: test\ndescription: desc\ndate: 2024-01-01\nauthor: Test\ntags: []\n---\n${longContent}`,
 		);
@@ -300,13 +308,91 @@ describe("getBlogPost", () => {
 	});
 
 	it("sets readingTime as non-empty string", () => {
-		vi.mocked(fs.existsSync).mockReturnValue(false);
+		vi.mocked(fs.existsSync).mockReturnValue(true);
 		vi.mocked(fs.readFileSync).mockReturnValue(
 			mockPost("reading-test", { date: "2024-01-01" }),
 		);
 		const post = getBlogPost("reading-test");
 		expect(typeof post.readingTime).toBe("string");
 		expect(post.readingTime.length).toBeGreaterThan(0);
+	});
+});
+
+describe("getBlogPost validation", () => {
+	it("throws BlogPostNotFoundError when no content file exists", () => {
+		vi.mocked(fs.existsSync).mockReturnValue(false);
+		expect(() => getBlogPost("no-such-post")).toThrow(BlogPostNotFoundError);
+		expect(() => getBlogPost("no-such-post")).toThrow(
+			'Blog post not found: "no-such-post"',
+		);
+	});
+
+	it("does not touch the filesystem when the post is missing", () => {
+		vi.mocked(fs.existsSync).mockReturnValue(false);
+		expect(() => getBlogPost("no-such-post")).toThrow(BlogPostNotFoundError);
+		expect(vi.mocked(fs.readFileSync)).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		["../../etc/passwd", "path traversal"],
+		["nested/slug", "path separator"],
+		["Upper-Case", "uppercase letters"],
+		["has_underscore", "underscore"],
+		["", "empty string"],
+	])("rejects %s (%s) with InvalidBlogSlugError", (slug) => {
+		expect(() => getBlogPost(slug)).toThrow(InvalidBlogSlugError);
+	});
+
+	it("rejects an invalid slug before building a path", () => {
+		expect(() => getBlogPost("../../etc/passwd")).toThrow(InvalidBlogSlugError);
+		expect(vi.mocked(fs.existsSync)).not.toHaveBeenCalled();
+		expect(vi.mocked(fs.readFileSync)).not.toHaveBeenCalled();
+	});
+
+	it("throws BlogFrontmatterError naming the file and the missing field", () => {
+		vi.mocked(fs.existsSync).mockReturnValue(true);
+		// `description` and `author` are required by BlogFrontmatterSchema.
+		vi.mocked(fs.readFileSync).mockReturnValue(
+			'---\ntitle: "Only a title"\ndate: "2024-01-01"\n---\nBody',
+		);
+
+		expect(() => getBlogPost("bad-frontmatter")).toThrow(BlogFrontmatterError);
+
+		let message = "";
+		try {
+			getBlogPost("bad-frontmatter");
+		} catch (error) {
+			message = (error as Error).message;
+		}
+
+		expect(message).toContain("bad-frontmatter.mdx");
+		expect(message).toContain("description");
+		expect(message).toContain("author");
+	});
+
+	it("reports the offending field for a wrong-typed value", () => {
+		vi.mocked(fs.existsSync).mockReturnValue(true);
+		vi.mocked(fs.readFileSync).mockReturnValue(
+			'---\ntitle: "T"\ndescription: "D"\ndate: "2024-01-01"\nauthor: "A"\ntags: "not-an-array"\n---\nBody',
+		);
+
+		let message = "";
+		try {
+			getBlogPost("bad-tags");
+		} catch (error) {
+			message = (error as Error).message;
+		}
+
+		expect(message).toContain("bad-tags.mdx");
+		expect(message).toContain("tags");
+	});
+
+	it("accepts frontmatter that satisfies the schema", () => {
+		vi.mocked(fs.existsSync).mockReturnValue(true);
+		vi.mocked(fs.readFileSync).mockReturnValue(
+			mockPost("good-post", { date: "2024-01-01" }),
+		);
+		expect(getBlogPost("good-post").frontmatter.title).toBe("good-post");
 	});
 });
 
@@ -331,7 +417,7 @@ describe("getBlogPostsByCategory", () => {
 			"process-post.mdx",
 			"other-post.mdx",
 		] as never);
-		vi.mocked(fs.existsSync).mockReturnValue(false);
+		vi.mocked(fs.existsSync).mockReturnValue(true);
 		vi.mocked(fs.readFileSync).mockImplementation((filePath: unknown) => {
 			if (String(filePath).includes("dev-post"))
 				return mockPost("dev-post", {
@@ -373,7 +459,7 @@ describe("getCategoryPostCounts", () => {
 			"dev-post.mdx",
 			"process-post.mdx",
 		] as never);
-		vi.mocked(fs.existsSync).mockReturnValue(false);
+		vi.mocked(fs.existsSync).mockReturnValue(true);
 		vi.mocked(fs.readFileSync).mockImplementation((filePath: unknown) => {
 			if (String(filePath).includes("dev-post"))
 				return mockPost("dev-post", {
@@ -409,7 +495,7 @@ describe("getYearPostCounts", () => {
 			"y2024-b.mdx",
 			"y2023.mdx",
 		] as never);
-		vi.mocked(fs.existsSync).mockReturnValue(false);
+		vi.mocked(fs.existsSync).mockReturnValue(true);
 		vi.mocked(fs.readFileSync).mockImplementation((filePath: unknown) => {
 			if (String(filePath).includes("y2024"))
 				return mockPost(`${String(filePath).match(/y\d+-?\w*/)?.[0]}`, {
@@ -427,7 +513,7 @@ describe("getYearPostCounts", () => {
 const setupNPosts = (n: number) => {
 	const files = Array.from({ length: n }, (_, i) => `post-${i}.mdx`);
 	vi.mocked(fs.readdirSync).mockReturnValue(files as never);
-	vi.mocked(fs.existsSync).mockReturnValue(false);
+	vi.mocked(fs.existsSync).mockReturnValue(true);
 	vi.mocked(fs.readFileSync).mockImplementation((filePath: unknown) => {
 		const match = String(filePath).match(/post-(\d+)/);
 		const idx = match ? Number(match[1]) : 0;
@@ -488,7 +574,7 @@ describe("getPaginatedPostsByCategory", () => {
 			"dev.mdx",
 			"other.mdx",
 		] as never);
-		vi.mocked(fs.existsSync).mockReturnValue(false);
+		vi.mocked(fs.existsSync).mockReturnValue(true);
 		vi.mocked(fs.readFileSync).mockImplementation((filePath: unknown) => {
 			if (String(filePath).includes("dev"))
 				return mockPost("dev", { date: "2024-01-01", tags: "web-development" });
@@ -513,7 +599,7 @@ describe("getPaginatedPostsByYear", () => {
 			"y2024.mdx",
 			"y2023.mdx",
 		] as never);
-		vi.mocked(fs.existsSync).mockReturnValue(false);
+		vi.mocked(fs.existsSync).mockReturnValue(true);
 		vi.mocked(fs.readFileSync).mockImplementation((filePath: unknown) => {
 			if (String(filePath).includes("y2024"))
 				return mockPost("y2024", { date: "2024-06-01" });


### PR DESCRIPTION
> **Stacks on #71** (`perf/blog-data-caching`). Base is set to that branch, not `main`. Review #71 first; this diff is only the validation layer on top of it.

## Problem

`src/lib/blog.ts` cast frontmatter with `data as BlogFrontmatter` — an unchecked assertion. `BlogFrontmatterSchema` already existed in `src/content/schema.ts` but was only exercised by `test/content.test.ts`, so **production had zero runtime validation**. Malformed frontmatter became a confusing render crash deep in a component instead of a clear build error. Separately, `getBlogPost("no-such-post")` threw a raw `ENOENT`, and the slug flowed unvalidated into `path.join`.

## Changes

- **Frontmatter validation** — `BlogFrontmatterSchema.safeParse` replaces the cast. On failure, `BlogFrontmatterError` names the offending file and lists each failing field with its path.
- **Slug guard** — slugs are validated against `/^[a-z0-9-]+$/` *before* any path is constructed. Traversal (`../../etc/passwd`), separators, and uppercase are rejected with `InvalidBlogSlugError`.
- **Missing posts** — `BlogPostNotFoundError` replaces the raw `ENOENT`.
- **Type/schema drift** — `BlogFrontmatter` is now derived via `z.infer` from the schema, so the runtime check and the compile-time type cannot diverge.

### On the missing-post case

`getBlogPost` **keeps its `BlogPost` return type** rather than widening to `BlogPost | null`. Every caller was checked with grep: the only production caller is `src/app/blog/[slug]/page.tsx` (twice), which already wraps the call in `try`/`catch` and routes to `notFound()`. Widening the return type would have forced null-handling at each call site for no behavioral gain. Throwing a typed error keeps the diff minimal and reuses the existing path.

Verified end-to-end against a production server, not just asserted:

| Request | Status |
| --- | --- |
| `/blog/no-such-post` | `404` |
| `/blog/designing-the-interface` | `200` |

### One thing worth flagging

The schema's `date: z.string()` was stricter than the content format. YAML parses an unquoted `date: 2024-01-01` into a **`Date` object**, and only a quoted `date: "2024-01-01"` into a string. All six current posts happen to quote their dates, so the build passes either way — but an author writing idiomatic unquoted YAML would have hit a hard build failure. The schema now accepts both and normalizes `Date` to `YYYY-MM-DD`. Downstream code only does `new Date(frontmatter.date)`, which is unaffected.

## Tests

Added coverage for invalid frontmatter (missing required fields and a wrong-typed value, asserting the message names the file *and* the field), traversal/invalid slugs (including that no `fs` call is made), and the missing-post case.

Several existing fixtures mocked `existsSync` to `false` while still returning file contents via `readFileSync` — incoherent, and it only ever worked because the old code used the `.md` path without checking existence. Those fixtures encoded the bug being fixed, so they now mock the filesystem truthfully.

## Verification

- `bun run tsc` — clean
- `bun test` — 121 pass, 0 fail
- `bun run check` — clean
- `bun run knip` — clean
- `bun run build` — succeeds, all 6 posts prerendered, **confirming real content still validates**

🤖 Generated with [Claude Code](https://claude.com/claude-code)