### PR TITLE
fix: exclude agent worktrees from Biome file discovery

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -17,6 +17,8 @@
 			"*.tsx",
 			"*.jsx",
 			"*.json",
+			"!.claude/worktrees",
+			"!.worktrees",
 			"!node_modules",
 			"!.next",
 			"!dist",


### PR DESCRIPTION
## Problem

The Stop hook was failing with:

```
× Found a nested root configuration, but there's already a root configuration.
```

`biome.json` includes `.claude/**/*`, which pulls in `.claude/worktrees/`. Each agent worktree is a full checkout of the repo, so each carries its own `biome.json`. Biome v2 treats those as nested root configurations and refuses to run.

## Fix

Exclude `.claude/worktrees` and `.worktrees` from file discovery. The `.claude/**/*` include exists to cover hooks and scripts, not nested checkouts.

## Verification

`bun run check` — checked 143 files, no error. Previously exited non-zero before linting anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)