### PR TITLE
docs: rewrite CLAUDE.md and add blog and test guides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,54 +1,37 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Personal website at <https://www.yongchenglow.com>. Next.js App Router, React 19, TypeScript, Tailwind v4 with shadcn/ui, MDX blog. Bun is both the package manager and the runtime — use `bun` and `bunx` for every install, script, and one-off command.
 
-## Project Overview
+## Gates
 
-This is Yong Cheng Low's personal website (<https://www.yongchenglow.com>), built with Next.js, React, TypeScript, and shadcn/ui with Tailwind CSS. The site features a blog with individual page-based routing and follows atomic design patterns for components.
+Before calling work done, run `bun run check:all` (tsc, then Biome check, then Knip) and `bun test`. Both must pass.
 
-## Essential Commands
+Dev server: `bun run dev`. Production build: `bun run build`. Every other script is in `package.json`.
 
-**Development:**
+## Layout
 
-- `bun run dev` - Start development server
-- `bun run build` - Build for production
-- `bun start` - Run production build
-- `bun run prepare` - Setup development environment (run once after clone)
+- `src/app/` — routes. `src/app/api/` — route handlers.
+- `src/components/shared/{atoms,molecules,organisms}/` — atomic design; place a new shared component by how many other components it composes.
+- `src/components/shared/ui/` — shadcn/ui primitives. Add these with the shadcn CLI rather than by hand.
+- `src/components/blog/` — blog-specific components, outside the atomic tiers.
+- `src/lib/` — data access and helpers. `src/config/` — tunable constants. `src/types/` — shared types.
+- `content/` — all copy and posts as JSON and MDX. `test/` — tests, mirroring the `src/` path.
 
-**Code Quality (always run after changes):**
+## Conventions
 
-- `bun run check` - Run Biome linting and formatting with auto-fix
-- `bun test` - Run tests with the Bun test runner
-- `bun run lint` - Run Biome linter only
-- `bun run format` - Format code only
-- `bun run knip` - Find unused files, dependencies, and exports
-- `bun run knip:production` - Check production dependencies only
+- Import named bindings from React: `import { useState } from "react"`.
+- Import across directories with the `@/*` alias, which resolves from the repo root.
+- TypeScript targets es2024 with `strictNullChecks` and `noUnusedLocals` on, and `strict` off. An unused local is a build failure.
+- Biome owns formatting and lint rules; run `bun run check` and take its output as authoritative rather than hand-formatting.
+- Conventional commits, enforced by commitlint on every commit. Branches: `feature/<name>` or `hotfix/<name>`.
 
-**Tools:**
+## Content is schema-validated
 
-- `bun run analyze` - Bundle analysis with webpack-bundle-analyzer
+Everything under `content/` is parsed through a Zod schema in `src/content/schema.ts`. A missing or misshapen field is a loud build-time failure, by design — so when a build breaks on content, fix the content or the schema, never the component that consumed it.
 
-## Architecture
+Editing or adding a blog post: read `src/app/blog/CLAUDE.md` for the frontmatter contract, the slug rule, and how tags reach category pages.
 
-- **Pages:** `src/app/` - Next.js App Router with file-based routing, individual blog posts as separate files
-- **Components:** `src/components/shared/atoms/`, `src/components/shared/molecules/`, and `src/components/shared/organisms/` - Atomic design pattern
-- **UI Components:** `src/components/shared/ui/` - shadcn/ui components
-- **Styling:** Tailwind CSS with shadcn/ui, custom theme via CSS variables in `globals.css`
-- **Fonts:** Custom font configuration in `src/components/theme/font.ts`
-
-## Code Standards
-
-- **Linting/Formatting:** Biome (replaced ESLint/Prettier) - config in `biome.json`
-- **Dead Code Detection:** Knip - config in `knip.json` - finds unused files, dependencies, and exports
-- **Style:** Tab indentation, double quotes, organized imports
-- **TypeScript:** ES2020 target, path mapping `@/*` to project root
-- **Git:** Conventional commits, branch naming: `feature/<name>` or `hotfix/<name>`
-- **Commit types:** feat, fix, docs, style, refactor, test, chore, build, ci, perf, revert
-- **Imports:** do not use import * as React from react instead import the variables separately.
-
-## Package Manager
-
-Uses `bun` (v1.4.2) as both package manager and runtime - do not use npm, pnpm, or yarn commands.
+Writing or fixing a test: read `test/CLAUDE.md` — the runner is `bun:test` behind a Vitest-shaped shim, and the mocking API differs from what its call sites look like.
 
 <!-- BEGIN:nextjs-agent-rules -->
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Personal website at <https://www.yongchenglow.com>. Next.js App Router, React 19
 
 Before calling work done, run `bun run check:all` (tsc, then Biome check, then Knip) and `bun test`. Both must pass.
 
-Dev server: `bun run dev`. Production build: `bun run build`. Every other script is in `package.json`.
+Scripts live in `package.json`; `bun run dev` and `bun run build` both regenerate the search index first.
 
 ## Layout
 
@@ -21,7 +21,7 @@ Dev server: `bun run dev`. Production build: `bun run build`. Every other script
 
 - Import named bindings from React: `import { useState } from "react"`.
 - Import across directories with the `@/*` alias, which resolves from the repo root.
-- TypeScript targets es2024 with `strictNullChecks` and `noUnusedLocals` on, and `strict` off. An unused local is a build failure.
+- TypeScript targets es2024. `strict` is off but `strictNullChecks` is on — null and undefined are tracked, while implicit `any` passes. `noUnusedLocals` is on, so a stray import or variable fails the build.
 - Biome owns formatting and lint rules; run `bun run check` and take its output as authoritative rather than hand-formatting.
 - Conventional commits, enforced by commitlint on every commit. Branches: `feature/<name>` or `hotfix/<name>`.
 
@@ -31,7 +31,7 @@ Everything under `content/` is parsed through a Zod schema in `src/content/schem
 
 Editing or adding a blog post: read `src/app/blog/CLAUDE.md` for the frontmatter contract, the slug rule, and how tags reach category pages.
 
-Writing or fixing a test: read `test/CLAUDE.md` — the runner is `bun:test` behind a Vitest-shaped shim, and the mocking API differs from what its call sites look like.
+Writing a test, or diagnosing one that fails or leaks state between cases: read `test/CLAUDE.md` — the runner is `bun:test` behind a Vitest-shaped shim, and the mocking API differs from what its call sites look like.
 
 <!-- BEGIN:nextjs-agent-rules -->
 

--- a/src/app/blog/CLAUDE.md
+++ b/src/app/blog/CLAUDE.md
@@ -1,0 +1,37 @@
+# Blog
+
+Routes here render posts that live in `content/blog/`, one post per file. Prefer `.mdx`; `.md` is also read.
+
+Keep this file and every other non-post document out of `content/blog/` — that directory is globbed by extension, so any `.md` placed there is parsed as a post and fails the build on missing frontmatter.
+
+## Slug
+
+The filename is the slug and the URL. It must match `^[a-z0-9-]+$` — lowercase, digits, hyphens. Anything else throws `InvalidBlogSlugError` at parse time, because slugs are joined straight onto a filesystem path.
+
+## Frontmatter
+
+Validated by `BlogFrontmatterSchema` in `src/content/schema.ts`. A violation fails the build with the file and field named.
+
+Required: `title`, `description`, `date`, `author`.
+
+Optional: `subtitle`, `lastUpdated`, `tags`, `image`, `draft`, `featured`, `adsSlotId`.
+
+- `date` and `lastUpdated` are `YYYY-MM-DD`. Quote them — YAML parses a bare date into a `Date`, which the schema then coerces back to a string, so the quoted form is the one that round-trips predictably.
+- `author` is a filename stem under `content/authors/`.
+- `image` is a path under `public/`, served from the root: `/img/example.png`.
+- `draft: true` hides the post from every listing, sitemap, and search index while leaving its direct URL live.
+- `featured: true` promotes the post to the featured slot. Only the first such post wins; with none, the newest post fills the slot.
+
+## Tags drive category pages
+
+A tag surfaces a post on a category page only if that exact tag is listed under a category in `src/config/blog.ts`. An unlisted tag still gets its own `/blog/tag/<tag>` page but reaches no category. When a new post's tags belong to an existing category, reuse that category's spelling; when they do not, add them to the category in `src/config/blog.ts` deliberately.
+
+## Excerpt and reading time
+
+Both are derived, never authored. The excerpt is the first paragraph truncated to 200 characters, and reading time is computed from the body — so the opening paragraph doubles as listing copy.
+
+## After adding or renaming a post
+
+`bun run dev` and `bun run build` regenerate `public/search-index.json` first, so a post is searchable through either. Inspecting that file without running one of them shows a stale index; `bun run generate-search-index` refreshes it on its own.
+
+Blog UI text — headings, badges, pagination labels — lives in `content/blog-ui.json`, not in components.

--- a/src/app/blog/CLAUDE.md
+++ b/src/app/blog/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Routes here render posts that live in `content/blog/`, one post per file. Prefer `.mdx`; `.md` is also read.
 
-Keep this file and every other non-post document out of `content/blog/` — that directory is globbed by extension, so any `.md` placed there is parsed as a post and fails the build on missing frontmatter.
+`content/blog/` holds posts and nothing else — it is globbed by extension, so every `.md` and `.mdx` there is parsed as a post and fails the build on missing frontmatter. Documentation about posts belongs here, beside the route.
 
 ## Slug
 

--- a/test/CLAUDE.md
+++ b/test/CLAUDE.md
@@ -1,0 +1,29 @@
+# Tests
+
+Run with `bun test`. The runner is `bun:test`, not Jest or Vitest — import `describe`, `it`, and `expect` from `"bun:test"`.
+
+Test files mirror the source path: `src/components/blog/Pagination.tsx` is tested by `test/components/blog/Pagination.test.tsx`.
+
+## The `vi` shim
+
+`test/bun-test-utils.ts` exposes a Vitest-shaped `vi` over Bun's primitives, so existing call sites like `vi.fn()` and `vi.spyOn()` keep working. Import it by relative path from the test file — `import { vi } from "../../bun-test-utils"` from a file two levels deep.
+
+`vi.mock` is deliberately absent. Module mocking is `mock.module`, imported from `"bun:test"`:
+
+```ts
+import { mock } from "bun:test";
+
+mock.module("@/src/lib/blog", () => ({ getAllBlogPosts: () => [] }));
+```
+
+`mock.module` does not hoist. Call it at the top level of the file, above the code under test, rather than inside a `describe` or `it`.
+
+## Setup runs automatically
+
+`bunfig.toml` preloads `test/setup.ts` before every file, which registers a happy-dom DOM at `http://localhost:3000`, loads jest-dom's matchers through their `/vitest` entry, mocks `next/navigation` and `IntersectionObserver`, and calls `afterEach(cleanup)` — Bun does not unmount rendered trees on its own. Add a globally-needed mock there; keep a single test's mock in that test.
+
+Type declarations for the jest-dom matchers live in `test/matchers.d.ts`, which augments `bun:test` directly.
+
+## Blog data is cached at module scope
+
+`src/lib/blog.ts` memoizes parsed posts for the process lifetime. A test that swaps `fs` fixtures between cases calls `resetBlogCache()` in `beforeEach`, or the previous case's content leaks into the next one.

--- a/test/CLAUDE.md
+++ b/test/CLAUDE.md
@@ -20,7 +20,14 @@ mock.module("@/src/lib/blog", () => ({ getAllBlogPosts: () => [] }));
 
 ## Setup runs automatically
 
-`bunfig.toml` preloads `test/setup.ts` before every file, which registers a happy-dom DOM at `http://localhost:3000`, loads jest-dom's matchers through their `/vitest` entry, mocks `next/navigation` and `IntersectionObserver`, and calls `afterEach(cleanup)` — Bun does not unmount rendered trees on its own. Add a globally-needed mock there; keep a single test's mock in that test.
+`bunfig.toml` preloads `test/setup.ts` before every file. It provides:
+
+- A happy-dom DOM at an explicit `http://localhost:3000`. The URL is not incidental: `next/image` resolves relative `src` values against `document.location` and throws `Invalid URL` on an `about:blank` base.
+- jest-dom's matchers, loaded through their `/vitest` entry.
+- Mocks for `next/navigation` and `IntersectionObserver`.
+- `afterEach(cleanup)` — Bun does not unmount rendered trees on its own.
+
+Add a globally-needed mock there; keep a single test's mock in that test.
 
 Type declarations for the jest-dom matchers live in `test/matchers.d.ts`, which augments `bun:test` directly.
 


### PR DESCRIPTION
## Summary

Rewrites the root `CLAUDE.md` and adds two directory-scoped guides, applying the `writing-for-agents` levers: cut material the environment already answers, correct stale facts, and push branch-specific reference behind pointers.

## Root `CLAUDE.md`

- **Cut the command list.** It duplicated `package.json` and had already gone stale — it listed `bun run prepare` while omitting `check:all`, `typecheck`, `generate-search-index`, and `lqip`. Replaced by the `bun run check:all` / `bun test` gates plus a pointer to the scripts.
- **Fixed a wrong fact.** The TypeScript target is `es2024`, not ES2020.
- **Filled gaps.** `src/components/blog/` and `src/config/` were missing from the layout section entirely.
- **Positive phrasing.** "use `bun` and `bunx` for every install" and "import named bindings from React" replace the two `do not` prohibitions — steering by prohibition makes the banned behaviour more available, not less.
- Dropped exposition that changes no behaviour (project overview prose, "Biome replaced ESLint/Prettier").

Net 59 lines changed, ending shorter. The `nextjs-agent-rules` block is preserved verbatim.

## `src/app/blog/CLAUDE.md`

The authoring contract an agent cannot infer from a post file: required vs optional frontmatter, why dates must be quoted, the `^[a-z0-9-]+$` slug alphabet, `draft` hiding listings but not the direct URL, and the tag→category coupling in `src/config/blog.ts`.

Placed in `src/app/blog/` rather than beside the posts because `content/blog/` is globbed by extension — `src/lib/blog.ts` and `test/content.test.ts` both treat any `.md` there as a post. The first draft did live in `content/blog/` and broke 8 tests; the guide now documents that trap.

## `test/CLAUDE.md`

The harness is `bun:test` behind a Vitest-shaped `vi` shim, and the mismatch is a live trap: `vi.mock` deliberately does not exist, because Bun's `mock.module` is hoisting-free and must be called at top level. Also covers the auto-preloaded `test/setup.ts` and the `resetBlogCache()` requirement for the module-scope blog cache.

## Verification

`bun test` — 121 pass, 0 fail. `bun run check:all` — tsc, Biome, and Knip all clean. `bun run build` — succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)