### PR TITLE
fix: prevent invalid MDX element nesting

### DIFF
--- a/src/components/blog/ImageModal.tsx
+++ b/src/components/blog/ImageModal.tsx
@@ -54,7 +54,7 @@ export const ImageModal = ({
 						className,
 					)}
 				>
-					<div className="w-full">
+					<span className="block w-full">
 						<Image
 							src={src}
 							alt={alt}
@@ -67,7 +67,7 @@ export const ImageModal = ({
 							quality={85}
 							loading="lazy"
 						/>
-					</div>
+					</span>
 				</button>
 			</DialogPrimitive.Trigger>
 

--- a/src/components/mdx/MDXComponents.tsx
+++ b/src/components/mdx/MDXComponents.tsx
@@ -1,4 +1,5 @@
 import type { MDXComponents } from "mdx/types";
+import { Children, isValidElement, type ReactNode } from "react";
 import { Admonition } from "@/src/components/mdx/Admonition";
 import { MermaidDiagram } from "@/src/components/mdx/MermaidDiagram";
 import { PostCodeBlock } from "@/src/components/post/PostCodeBlock";
@@ -15,6 +16,11 @@ import {
 	TableRow,
 } from "@/src/components/shared/ui/table";
 
+interface CodeElementProps {
+	children?: ReactNode;
+	className?: string;
+}
+
 export const useMDXComponents = (components: MDXComponents): MDXComponents => {
 	return {
 		// Map HTML elements to custom components
@@ -22,15 +28,7 @@ export const useMDXComponents = (components: MDXComponents): MDXComponents => {
 		ul: (props) => <PostList type="unordered" {...props} />,
 		ol: (props) => <PostList type="ordered" {...props} />,
 		img: PostImage,
-		code: (props) => {
-			if (
-				props?.className?.includes("language-mermaid") ||
-				props?.className?.includes("mermaid")
-			) {
-				return <MermaidDiagram>{props.children}</MermaidDiagram>;
-			}
-			return <PostCodeBlock {...props} />;
-		},
+		code: (props) => <code {...props} />,
 
 		// Table components
 		table: Table,
@@ -46,8 +44,33 @@ export const useMDXComponents = (components: MDXComponents): MDXComponents => {
 		Admonition,
 		MermaidDiagram,
 
-		// Pre blocks - delegate to code handler (which detects mermaid)
-		pre: (props) => <>{props.children}</>,
+		// MDX wraps fenced code in pre > code. Handle the block at the pre level so
+		// inline code remains phrasing content and can safely appear in paragraphs.
+		pre: ({ children, ...props }) => {
+			const child =
+				Children.count(children) === 1 ? Children.only(children) : null;
+
+			if (isValidElement<CodeElementProps>(child)) {
+				const { children: code, className = "" } = child.props;
+
+				if (
+					className.includes("language-mermaid") ||
+					className.includes("mermaid")
+				) {
+					return <MermaidDiagram>{String(code ?? "")}</MermaidDiagram>;
+				}
+
+				return (
+					<PostCodeBlock
+						language={className.replace(/^language-/, "") || "text"}
+					>
+						{String(code ?? "")}
+					</PostCodeBlock>
+				);
+			}
+
+			return <pre {...props}>{children}</pre>;
+		},
 
 		// Allow overrides
 		...components,

--- a/src/components/post/PostImage.tsx
+++ b/src/components/post/PostImage.tsx
@@ -27,7 +27,7 @@ export const PostImage = ({
 	const aspectRatio = `${(width / height) * 100}%`;
 
 	return (
-		<div className={cn("w-full mb-4", className)}>
+		<span className={cn("block w-full mb-4", className)}>
 			{isLoading && (
 				<ImageSkeleton className="w-full" aspectRatio={aspectRatio} />
 			)}
@@ -50,6 +50,6 @@ export const PostImage = ({
 				onLoad={() => setIsLoading(false)}
 				{...props}
 			/>
-		</div>
+		</span>
 	);
 };

--- a/src/components/shared/atoms/ImageSkeleton.tsx
+++ b/src/components/shared/atoms/ImageSkeleton.tsx
@@ -24,9 +24,9 @@ export const ImageSkeleton = ({
 					: aspectRatio;
 
 	return (
-		<div
+		<span
 			className={cn(
-				"relative overflow-hidden rounded-lg",
+				"relative block overflow-hidden rounded-lg",
 				"bg-gradient-to-r from-muted via-muted-foreground/10 to-muted",
 				"animate-shimmer",
 				aspectClass,

--- a/test/components/mdx/MDXComponents.test.tsx
+++ b/test/components/mdx/MDXComponents.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+import { render } from "@testing-library/react";
+import { MDXRemote } from "next-mdx-remote/rsc";
+import { MdxImage, MdxLink } from "@/src/components/blog/MdxImage";
+import { useMDXComponents } from "@/src/components/mdx/MDXComponents";
+import { getAllBlogPosts } from "@/src/lib/blog";
+import { vi } from "../../bun-test-utils";
+
+// biome-ignore lint/correctness/useHookAtTopLevel: MDX names this pure component-map factory like a hook.
+const components = useMDXComponents({
+	img: MdxImage,
+	a: MdxLink,
+});
+
+const renderMdx = async (source: string) => {
+	const content = await MDXRemote({ source, components });
+	return render(content);
+};
+
+describe("MDXComponents", () => {
+	it("keeps inline code inside its paragraph", async () => {
+		const { container } = await renderMdx("Use `numeric(5,2)` for the price.");
+
+		expect(container.querySelector("p > code")?.textContent).toBe(
+			"numeric(5,2)",
+		);
+	});
+
+	it("renders fenced code outside paragraphs", async () => {
+		const { container } = await renderMdx(
+			"```sql\nSELECT * FROM products;\n```",
+		);
+		const pre = container.querySelector("pre");
+
+		expect(pre?.textContent).toBe("SELECT * FROM products;");
+		expect(pre?.closest("p")).toBeNull();
+	});
+
+	it("renders every blog post without invalid HTML nesting", async () => {
+		const consoleError = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => undefined);
+		let diagnostics = "";
+
+		try {
+			for (const post of getAllBlogPosts(true)) {
+				const view = await renderMdx(post.content);
+				view.unmount();
+			}
+
+			diagnostics = consoleError.mock.calls.flat().join("\n");
+		} finally {
+			consoleError.mockRestore();
+		}
+
+		expect(diagnostics).not.toContain("cannot be a descendant of");
+	});
+});


### PR DESCRIPTION
## Summary
- keep inline MDX code as phrasing content and handle fenced code at the pre boundary
- make blog image wrappers safe inside Markdown-generated paragraphs
- add regression coverage for inline code, fenced code, and every current blog post

## Root cause
The MDX code override rendered both inline and fenced code through a block component, producing paragraph > code > div/pre. Image wrappers similarly emitted div elements inside Markdown paragraphs.

## Verification
- bun test: 124 passed
- TypeScript check passed
- Biome check passed
- production build passed
- git diff --check passed