### PR TITLE
ci: deploy review apps for pull requests

### DIFF
--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -1,26 +1,21 @@
-name: CI/CD
+name: Review App
 
+# Build and deploy the pull request merge commit, then remove every resource
+# when the pull request closes. Forks still receive quality checks, but never
+# receive access to deployment credentials.
 on:
-  push:
+  pull_request:
     branches: [main]
-    # Documentation-only pushes should not build and publish a container image.
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
-      - "LICENSE"
-      - ".gitignore"
-
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+    types: [opened, synchronize, reopened, closed]
 
 jobs:
-  # Reusable workflows take bun_version as an input, and `with:` cannot run a
-  # script, so this stays a job. Sparse checkout keeps it to a few seconds.
   extract-bun-version:
     name: Extract Bun Version from package.json
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     outputs:
       bun_version: ${{ steps.get-bun-version.outputs.bun_version }}
     steps:
@@ -35,32 +30,35 @@ jobs:
         run: |
           BUN_VERSION=$(jq -r '.packageManager | split("@")[1]' package.json)
           if [ -z "$BUN_VERSION" ] || [ "$BUN_VERSION" = "null" ]; then
-            echo "✗ ERROR: Could not read bun version from package.json packageManager field"
+            echo "Could not read the Bun version from package.json"
             exit 1
           fi
-          echo "bun_version=$BUN_VERSION" >> $GITHUB_OUTPUT
+          echo "bun_version=$BUN_VERSION" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Quality Checks
+    if: github.event.action != 'closed'
+    needs: extract-bun-version
+    permissions:
+      contents: read
+      security-events: write
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      bun_version: ${{ needs.extract-bun-version.outputs.bun_version }}
 
   secret-scan:
     name: Secret Scan
+    if: github.event.action != 'closed'
     permissions:
       contents: read
       security-events: write
     uses: ./.github/workflows/reusable-secret-scan.yml
     secrets: inherit
 
-  build:
-    name: Quality Checks
-    permissions:
-      contents: read
-      security-events: write
-    needs: extract-bun-version
-    uses: ./.github/workflows/reusable-build.yml
-    with:
-      bun_version: ${{ needs.extract-bun-version.outputs.bun_version }}
-
   docker:
-    name: Build & Push Docker Image
-    needs: [build, secret-scan, extract-bun-version]
+    name: Build & Push Review Image
+    if: github.event.action != 'closed' && github.event.pull_request.head.repo.fork == false
+    needs: [extract-bun-version, build, secret-scan]
     permissions:
       contents: read
       packages: write
@@ -68,10 +66,12 @@ jobs:
     with:
       bun_version: ${{ needs.extract-bun-version.outputs.bun_version }}
       platforms: linux/amd64
+      tag_prefix: pr-${{ github.event.number }}
     secrets: inherit
 
   security-scan:
     name: Security Scan
+    if: github.event.action != 'closed' && github.event.pull_request.head.repo.fork == false
     needs: docker
     permissions:
       contents: read
@@ -82,15 +82,27 @@ jobs:
       image_tag: ${{ needs.docker.outputs.image_tag }}
     secrets: inherit
 
-  deploy-production:
-    name: Deploy to Production
-    if: github.ref == 'refs/heads/main'
+  deploy:
+    name: Deploy Review App
+    if: github.event.action != 'closed' && github.event.pull_request.head.repo.fork == false
     needs: [docker, security-scan]
     permissions:
       contents: read
       packages: read
       deployments: write
-    uses: ./.github/workflows/production-deploy.yml
+    uses: ./.github/workflows/review-deploy.yml
     with:
       image_tag: ${{ needs.docker.outputs.image_tag }}
+      review_id: pr-${{ github.event.number }}
+    secrets: inherit
+
+  cleanup:
+    name: Tear Down Review App
+    if: github.event.action == 'closed' && github.event.pull_request.head.repo.fork == false
+    permissions:
+      contents: read
+      deployments: write
+    uses: ./.github/workflows/review-cleanup.yml
+    with:
+      review_id: pr-${{ github.event.number }}
     secrets: inherit

--- a/.github/workflows/review-cleanup.yml
+++ b/.github/workflows/review-cleanup.yml
@@ -1,0 +1,247 @@
+name: Review App Cleanup
+
+on:
+  workflow_call:
+    inputs:
+      review_id:
+        description: Stable review identifier, such as pr-77
+        required: true
+        type: string
+
+env:
+  PORT_MAPPING_NAMESPACE: default
+  PORT_MAPPING_CONFIGMAP: yongchenglow-review-ports
+  INFRA_LOCK_CONFIGMAP: yongchenglow-review-infra-lock
+
+jobs:
+  cleanup:
+    name: Tear down ${{ inputs.review_id }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: review-app-${{ github.repository }}-${{ inputs.review_id }}
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - name: Validate configuration
+        env:
+          REVIEW_ID: ${{ inputs.review_id }}
+          KUBE_SERVER: ${{ secrets.KUBECONFIG_SERVER }}
+          KUBE_TOKEN: ${{ secrets.KUBECONFIG_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_TUNNEL_ID: ${{ secrets.CLOUDFLARE_TUNNEL_ID }}
+          CLOUDFLARE_DOMAIN: ${{ vars.CLOUDFLARE_DOMAIN }}
+        run: |
+          if ! [[ "$REVIEW_ID" =~ ^pr-[0-9]+$ ]]; then
+            echo "Invalid review_id: $REVIEW_ID"
+            exit 1
+          fi
+          missing=()
+          for name in KUBE_SERVER KUBE_TOKEN CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_TUNNEL_ID CLOUDFLARE_DOMAIN; do
+            if [ -z "${!name}" ]; then
+              missing+=("$name")
+            fi
+          done
+          if [ ${#missing[@]} -gt 0 ]; then
+            printf 'Missing required configuration: %s\n' "${missing[@]}"
+            exit 1
+          fi
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.13.0
+
+      - name: Configure Kubernetes
+        env:
+          KUBE_SERVER: ${{ secrets.KUBECONFIG_SERVER }}
+          KUBE_TOKEN: ${{ secrets.KUBECONFIG_TOKEN }}
+        run: |
+          mkdir -p ~/.kube
+          touch ~/.kube/config
+          chmod 600 ~/.kube/config
+          kubectl config set-cluster prod --server="$KUBE_SERVER"
+          kubectl config set-credentials deployer --token="$KUBE_TOKEN"
+          kubectl config set-context prod --cluster=prod --user=deployer
+          kubectl config use-context prod
+
+      - name: Remove Helm release and namespace
+        id: kubernetes
+        continue-on-error: true
+        env:
+          REVIEW_ID: ${{ inputs.review_id }}
+        run: |
+          namespace="yongchenglow-review-$REVIEW_ID"
+          if kubectl get namespace "$namespace" >/dev/null 2>&1; then
+            if helm status nextjs-app -n "$namespace" >/dev/null 2>&1; then
+              helm uninstall nextjs-app -n "$namespace" --wait --timeout 5m
+            fi
+            kubectl delete namespace "$namespace" --wait=true --timeout=5m
+          fi
+
+      - name: Remove Cloudflare tunnel route
+        id: tunnel
+        if: always()
+        continue-on-error: true
+        env:
+          REVIEW_ID: ${{ inputs.review_id }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_TUNNEL_ID: ${{ secrets.CLOUDFLARE_TUNNEL_ID }}
+          CLOUDFLARE_DOMAIN: ${{ vars.CLOUDFLARE_DOMAIN }}
+        run: |
+          lock_owner="$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-$GITHUB_JOB-tunnel"
+          release_lock() {
+            owner=$(kubectl get configmap "$INFRA_LOCK_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE" \
+              -o jsonpath='{.data.owner}' 2>/dev/null || true)
+            if [ "$owner" = "$lock_owner" ]; then
+              kubectl delete configmap "$INFRA_LOCK_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE" --wait=false >/dev/null
+            fi
+          }
+          trap release_lock EXIT
+
+          deadline=$((SECONDS + 180))
+          until kubectl create configmap "$INFRA_LOCK_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE" \
+            --from-literal="owner=$lock_owner" --from-literal="created_at=$(date +%s)" >/dev/null 2>&1; do
+            lock_json=$(kubectl get configmap "$INFRA_LOCK_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE" -o json 2>/dev/null || echo '{}')
+            stale_owner=$(jq -r '.data.owner // empty' <<< "$lock_json")
+            created_at=$(jq -r '.data.created_at // 0' <<< "$lock_json")
+            if [[ "$created_at" =~ ^[0-9]+$ ]] && [ "$created_at" -gt 0 ] && [ $(( $(date +%s) - created_at )) -gt 120 ]; then
+              current_owner=$(kubectl get configmap "$INFRA_LOCK_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE" \
+                -o jsonpath='{.data.owner}' 2>/dev/null || true)
+              if [ "$current_owner" = "$stale_owner" ]; then
+                echo "Removing stale review infrastructure lock owned by $stale_owner"
+                kubectl delete configmap "$INFRA_LOCK_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE" --wait=false >/dev/null || true
+              fi
+            fi
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "Timed out waiting for the review infrastructure lock"
+              exit 1
+            fi
+            sleep 5
+          done
+
+          hostname="$REVIEW_ID-review.$CLOUDFLARE_DOMAIN"
+          endpoint="https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/cfd_tunnel/$CLOUDFLARE_TUNNEL_ID/configurations"
+          current=$(curl --fail-with-body --silent --show-error "$endpoint" \
+            -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN")
+          jq -e '.success == true' <<< "$current" >/dev/null
+          config=$(jq --arg hostname "$hostname" '
+            .result.config |
+            .ingress = (((.ingress // []) | map(select(.hostname != $hostname and .service != "http_status:404")))
+              + [{service: "http_status:404"}])
+          ' <<< "$current")
+          payload=$(jq -cn --argjson config "$config" '{config:$config}')
+          response=$(curl --fail-with-body --silent --show-error -X PUT "$endpoint" \
+            -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            -H "Content-Type: application/json" \
+            --data "$payload")
+          jq -e '.success == true' <<< "$response" >/dev/null
+
+      - name: Remove Cloudflare DNS record
+        id: dns
+        if: always()
+        continue-on-error: true
+        env:
+          REVIEW_ID: ${{ inputs.review_id }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_DOMAIN: ${{ vars.CLOUDFLARE_DOMAIN }}
+        run: |
+          hostname="$REVIEW_ID-review.$CLOUDFLARE_DOMAIN"
+          auth=(-H "Authorization: Bearer $CLOUDFLARE_API_TOKEN")
+          zone_response=$(curl --fail-with-body --silent --show-error \
+            "https://api.cloudflare.com/client/v4/zones?name=$CLOUDFLARE_DOMAIN" "${auth[@]}")
+          zone_id=$(jq -er '.result[0].id' <<< "$zone_response")
+          records_url="https://api.cloudflare.com/client/v4/zones/$zone_id/dns_records"
+          existing=$(curl --fail-with-body --silent --show-error \
+            "$records_url?type=CNAME&name=$hostname" "${auth[@]}")
+          record_id=$(jq -r '.result[0].id // empty' <<< "$existing")
+          if [ -n "$record_id" ]; then
+            response=$(curl --fail-with-body --silent --show-error -X DELETE \
+              "$records_url/$record_id" "${auth[@]}")
+            jq -e '.success == true' <<< "$response" >/dev/null
+          fi
+
+      - name: Release NodePort
+        id: port
+        if: always()
+        continue-on-error: true
+        env:
+          REVIEW_ID: ${{ inputs.review_id }}
+        run: |
+          lock_owner="$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-$GITHUB_JOB-port"
+          release_lock() {
+            owner=$(kubectl get configmap "$INFRA_LOCK_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE" \
+              -o jsonpath='{.data.owner}' 2>/dev/null || true)
+            if [ "$owner" = "$lock_owner" ]; then
+              kubectl delete configmap "$INFRA_LOCK_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE" --wait=false >/dev/null
+            fi
+          }
+          trap release_lock EXIT
+
+          deadline=$((SECONDS + 180))
+          until kubectl create configmap "$INFRA_LOCK_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE" \
+            --from-literal="owner=$lock_owner" --from-literal="created_at=$(date +%s)" >/dev/null 2>&1; do
+            lock_json=$(kubectl get configmap "$INFRA_LOCK_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE" -o json 2>/dev/null || echo '{}')
+            stale_owner=$(jq -r '.data.owner // empty' <<< "$lock_json")
+            created_at=$(jq -r '.data.created_at // 0' <<< "$lock_json")
+            if [[ "$created_at" =~ ^[0-9]+$ ]] && [ "$created_at" -gt 0 ] && [ $(( $(date +%s) - created_at )) -gt 120 ]; then
+              current_owner=$(kubectl get configmap "$INFRA_LOCK_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE" \
+                -o jsonpath='{.data.owner}' 2>/dev/null || true)
+              if [ "$current_owner" = "$stale_owner" ]; then
+                echo "Removing stale review infrastructure lock owned by $stale_owner"
+                kubectl delete configmap "$INFRA_LOCK_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE" --wait=false >/dev/null || true
+              fi
+            fi
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "Timed out waiting for the review infrastructure lock"
+              exit 1
+            fi
+            sleep 5
+          done
+
+          if kubectl get configmap "$PORT_MAPPING_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE" >/dev/null 2>&1; then
+            mappings=$(kubectl get configmap "$PORT_MAPPING_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE" -o json)
+            if jq -e --arg key "$REVIEW_ID" '.data[$key] != null' <<< "$mappings" >/dev/null; then
+              kubectl patch configmap "$PORT_MAPPING_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE" \
+                --type json --patch "$(jq -cn --arg key "$REVIEW_ID" '[{op:"remove",path:("/data/" + $key)}]')"
+            fi
+          fi
+
+      - name: Mark GitHub deployments inactive
+        id: deployments
+        if: always()
+        continue-on-error: true
+        uses: actions/github-script@v9
+        env:
+          ENVIRONMENT_NAME: review/${{ inputs.review_id }}
+        with:
+          script: |
+            const deployments = await github.paginate(github.rest.repos.listDeployments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              environment: process.env.ENVIRONMENT_NAME,
+            });
+            for (const deployment of deployments) {
+              await github.rest.repos.createDeploymentStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: deployment.id,
+                state: "inactive",
+              });
+            }
+
+      - name: Report cleanup failures
+        if: >-
+          always() &&
+          (steps.kubernetes.outcome == 'failure' ||
+           steps.tunnel.outcome == 'failure' ||
+           steps.dns.outcome == 'failure' ||
+           steps.port.outcome == 'failure' ||
+           steps.deployments.outcome == 'failure')
+        run: |
+          echo "One or more review-app resources could not be removed; inspect the failed steps above."
+          exit 1

--- a/.github/workflows/review-deploy.yml
+++ b/.github/workflows/review-deploy.yml
@@ -1,0 +1,273 @@
+name: Review App Deploy
+
+on:
+  workflow_call:
+    inputs:
+      image_tag:
+        description: Docker image tag to deploy
+        required: true
+        type: string
+      review_id:
+        description: Stable review identifier, such as pr-77
+        required: true
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  SOURCE_NAMESPACE: personal-site
+  PORT_MAPPING_NAMESPACE: default
+  PORT_MAPPING_CONFIGMAP: yongchenglow-review-ports
+  INFRA_LOCK_CONFIGMAP: yongchenglow-review-infra-lock
+  PORT_RANGE_START: 31000
+  PORT_RANGE_END: 31999
+
+jobs:
+  deploy:
+    name: Deploy ${{ inputs.review_id }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Prevent an older update or a close event racing this PR's deployment.
+    # Cross-PR shared state is protected by a Kubernetes-backed mutex below.
+    concurrency:
+      group: review-app-${{ github.repository }}-${{ inputs.review_id }}
+      cancel-in-progress: false
+    environment:
+      name: review/${{ inputs.review_id }}
+      url: https://${{ inputs.review_id }}-review.${{ vars.CLOUDFLARE_DOMAIN }}
+    permissions:
+      contents: read
+      packages: read
+      deployments: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Validate configuration
+        env:
+          REVIEW_ID: ${{ inputs.review_id }}
+          KUBE_SERVER: ${{ secrets.KUBECONFIG_SERVER }}
+          KUBE_TOKEN: ${{ secrets.KUBECONFIG_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_TUNNEL_ID: ${{ secrets.CLOUDFLARE_TUNNEL_ID }}
+          CLOUDFLARE_DOMAIN: ${{ vars.CLOUDFLARE_DOMAIN }}
+        run: |
+          if ! [[ "$REVIEW_ID" =~ ^pr-[0-9]+$ ]]; then
+            echo "Invalid review_id: $REVIEW_ID"
+            exit 1
+          fi
+
+          missing=()
+          for name in KUBE_SERVER KUBE_TOKEN CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_TUNNEL_ID CLOUDFLARE_DOMAIN; do
+            if [ -z "${!name}" ]; then
+              missing+=("$name")
+            fi
+          done
+          if [ ${#missing[@]} -gt 0 ]; then
+            printf 'Missing required configuration: %s\n' "${missing[@]}"
+            exit 1
+          fi
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.13.0
+
+      - name: Configure Kubernetes
+        env:
+          KUBE_SERVER: ${{ secrets.KUBECONFIG_SERVER }}
+          KUBE_TOKEN: ${{ secrets.KUBECONFIG_TOKEN }}
+        run: |
+          mkdir -p ~/.kube
+          touch ~/.kube/config
+          chmod 600 ~/.kube/config
+          kubectl config set-cluster prod --server="$KUBE_SERVER"
+          kubectl config set-credentials deployer --token="$KUBE_TOKEN"
+          kubectl config set-context prod --cluster=prod --user=deployer
+          kubectl config use-context prod
+
+      - name: Allocate NodePort
+        id: port
+        env:
+          REVIEW_ID: ${{ inputs.review_id }}
+        run: |
+          lock_owner="$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-$GITHUB_JOB-port"
+          release_lock() {
+            owner=$(kubectl get configmap "$INFRA_LOCK_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE" \
+              -o jsonpath='{.data.owner}' 2>/dev/null || true)
+            if [ "$owner" = "$lock_owner" ]; then
+              kubectl delete configmap "$INFRA_LOCK_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE" --wait=false >/dev/null
+            fi
+          }
+          trap release_lock EXIT
+
+          deadline=$((SECONDS + 180))
+          until kubectl create configmap "$INFRA_LOCK_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE" \
+            --from-literal="owner=$lock_owner" --from-literal="created_at=$(date +%s)" >/dev/null 2>&1; do
+            lock_json=$(kubectl get configmap "$INFRA_LOCK_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE" -o json 2>/dev/null || echo '{}')
+            stale_owner=$(jq -r '.data.owner // empty' <<< "$lock_json")
+            created_at=$(jq -r '.data.created_at // 0' <<< "$lock_json")
+            if [[ "$created_at" =~ ^[0-9]+$ ]] && [ "$created_at" -gt 0 ] && [ $(( $(date +%s) - created_at )) -gt 120 ]; then
+              current_owner=$(kubectl get configmap "$INFRA_LOCK_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE" \
+                -o jsonpath='{.data.owner}' 2>/dev/null || true)
+              if [ "$current_owner" = "$stale_owner" ]; then
+                echo "Removing stale review infrastructure lock owned by $stale_owner"
+                kubectl delete configmap "$INFRA_LOCK_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE" --wait=false >/dev/null || true
+              fi
+            fi
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "Timed out waiting for the review infrastructure lock"
+              exit 1
+            fi
+            sleep 5
+          done
+
+          if ! kubectl get configmap "$PORT_MAPPING_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE" >/dev/null 2>&1; then
+            kubectl create configmap "$PORT_MAPPING_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE"
+          fi
+
+          mappings=$(kubectl get configmap "$PORT_MAPPING_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE" -o json)
+          port=$(jq -r --arg key "$REVIEW_ID" '.data[$key] // empty' <<< "$mappings")
+
+          if [ -z "$port" ]; then
+            allocated=$(jq -r '.data // {} | .[]' <<< "$mappings")
+            for candidate in $(seq "$PORT_RANGE_START" "$PORT_RANGE_END"); do
+              if ! grep -qx "$candidate" <<< "$allocated"; then
+                port=$candidate
+                break
+              fi
+            done
+            if [ -z "$port" ]; then
+              echo "No free NodePort in $PORT_RANGE_START-$PORT_RANGE_END"
+              exit 1
+            fi
+            kubectl patch configmap "$PORT_MAPPING_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE" \
+              --type merge --patch "$(jq -cn --arg key "$REVIEW_ID" --arg port "$port" '{data:{($key):$port}}')"
+          fi
+
+          echo "port=$port" >> "$GITHUB_OUTPUT"
+          echo "Using NodePort $port for $REVIEW_ID"
+
+      - name: Prepare review namespace
+        env:
+          REVIEW_ID: ${{ inputs.review_id }}
+        run: |
+          namespace="yongchenglow-review-$REVIEW_ID"
+          kubectl get namespace "$namespace" >/dev/null 2>&1 || kubectl create namespace "$namespace"
+
+          kubectl get secret ghcr-secret -n "$SOURCE_NAMESPACE" -o json |
+            jq --arg namespace "$namespace" '
+              .metadata.namespace = $namespace |
+              del(.metadata.creationTimestamp, .metadata.resourceVersion, .metadata.uid, .metadata.managedFields)
+            ' |
+            kubectl apply -f -
+
+      - name: Deploy with Helm
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag }}
+          REVIEW_ID: ${{ inputs.review_id }}
+          NODE_PORT: ${{ steps.port.outputs.port }}
+        run: |
+          image_name=$(tr '[:upper:]' '[:lower:]' <<< "${{ github.repository }}")
+          namespace="yongchenglow-review-$REVIEW_ID"
+
+          helm upgrade --install nextjs-app ./helm/nextjs-app \
+            --namespace "$namespace" \
+            --values ./helm/nextjs-app/values-review.yaml \
+            --set-string image.repository="$REGISTRY/$image_name" \
+            --set-string image.tag="$IMAGE_TAG" \
+            --set service.nodePort="$NODE_PORT" \
+            --wait \
+            --timeout 10m
+
+      - name: Configure Cloudflare tunnel route
+        env:
+          REVIEW_ID: ${{ inputs.review_id }}
+          NODE_PORT: ${{ steps.port.outputs.port }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_TUNNEL_ID: ${{ secrets.CLOUDFLARE_TUNNEL_ID }}
+          CLOUDFLARE_DOMAIN: ${{ vars.CLOUDFLARE_DOMAIN }}
+        run: |
+          lock_owner="$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-$GITHUB_JOB-tunnel"
+          release_lock() {
+            owner=$(kubectl get configmap "$INFRA_LOCK_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE" \
+              -o jsonpath='{.data.owner}' 2>/dev/null || true)
+            if [ "$owner" = "$lock_owner" ]; then
+              kubectl delete configmap "$INFRA_LOCK_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE" --wait=false >/dev/null
+            fi
+          }
+          trap release_lock EXIT
+
+          deadline=$((SECONDS + 180))
+          until kubectl create configmap "$INFRA_LOCK_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE" \
+            --from-literal="owner=$lock_owner" --from-literal="created_at=$(date +%s)" >/dev/null 2>&1; do
+            lock_json=$(kubectl get configmap "$INFRA_LOCK_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE" -o json 2>/dev/null || echo '{}')
+            stale_owner=$(jq -r '.data.owner // empty' <<< "$lock_json")
+            created_at=$(jq -r '.data.created_at // 0' <<< "$lock_json")
+            if [[ "$created_at" =~ ^[0-9]+$ ]] && [ "$created_at" -gt 0 ] && [ $(( $(date +%s) - created_at )) -gt 120 ]; then
+              current_owner=$(kubectl get configmap "$INFRA_LOCK_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE" \
+                -o jsonpath='{.data.owner}' 2>/dev/null || true)
+              if [ "$current_owner" = "$stale_owner" ]; then
+                echo "Removing stale review infrastructure lock owned by $stale_owner"
+                kubectl delete configmap "$INFRA_LOCK_CONFIGMAP" -n "$PORT_MAPPING_NAMESPACE" --wait=false >/dev/null || true
+              fi
+            fi
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "Timed out waiting for the review infrastructure lock"
+              exit 1
+            fi
+            sleep 5
+          done
+
+          hostname="$REVIEW_ID-review.$CLOUDFLARE_DOMAIN"
+          endpoint="https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/cfd_tunnel/$CLOUDFLARE_TUNNEL_ID/configurations"
+          current=$(curl --fail-with-body --silent --show-error "$endpoint" \
+            -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN")
+          jq -e '.success == true' <<< "$current" >/dev/null
+
+          config=$(jq --arg hostname "$hostname" --arg service "http://localhost:$NODE_PORT" '
+            .result.config |
+            .ingress = (((.ingress // []) | map(select(.hostname != $hostname and .service != "http_status:404")))
+              + [{hostname: $hostname, service: $service}, {service: "http_status:404"}])
+          ' <<< "$current")
+          payload=$(jq -cn --argjson config "$config" '{config:$config}')
+          response=$(curl --fail-with-body --silent --show-error -X PUT "$endpoint" \
+            -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            -H "Content-Type: application/json" \
+            --data "$payload")
+          jq -e '.success == true' <<< "$response" >/dev/null
+
+      - name: Configure Cloudflare DNS
+        env:
+          REVIEW_ID: ${{ inputs.review_id }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_TUNNEL_ID: ${{ secrets.CLOUDFLARE_TUNNEL_ID }}
+          CLOUDFLARE_DOMAIN: ${{ vars.CLOUDFLARE_DOMAIN }}
+        run: |
+          hostname="$REVIEW_ID-review.$CLOUDFLARE_DOMAIN"
+          headers=(-H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" -H "Content-Type: application/json")
+          zone_response=$(curl --fail-with-body --silent --show-error \
+            "https://api.cloudflare.com/client/v4/zones?name=$CLOUDFLARE_DOMAIN" "${headers[@]}")
+          zone_id=$(jq -er '.result[0].id' <<< "$zone_response")
+          records_url="https://api.cloudflare.com/client/v4/zones/$zone_id/dns_records"
+          existing=$(curl --fail-with-body --silent --show-error \
+            "$records_url?type=CNAME&name=$hostname" "${headers[@]}")
+          record_id=$(jq -r '.result[0].id // empty' <<< "$existing")
+          payload=$(jq -cn --arg name "$hostname" --arg content "$CLOUDFLARE_TUNNEL_ID.cfargotunnel.com" \
+            '{type:"CNAME", name:$name, content:$content, ttl:1, proxied:true}')
+
+          if [ -n "$record_id" ]; then
+            response=$(curl --fail-with-body --silent --show-error -X PUT "$records_url/$record_id" \
+              "${headers[@]}" --data "$payload")
+          else
+            response=$(curl --fail-with-body --silent --show-error -X POST "$records_url" \
+              "${headers[@]}" --data "$payload")
+          fi
+          jq -e '.success == true' <<< "$response" >/dev/null
+
+      - name: Publish review URL
+        env:
+          REVIEW_ID: ${{ inputs.review_id }}
+          CLOUDFLARE_DOMAIN: ${{ vars.CLOUDFLARE_DOMAIN }}
+        run: echo "Review app is available at https://$REVIEW_ID-review.$CLOUDFLARE_DOMAIN"

--- a/helm/nextjs-app/values-review.yaml
+++ b/helm/nextjs-app/values-review.yaml
@@ -1,0 +1,52 @@
+# Resource profile for ephemeral pull-request review apps.
+replicaCount: 1
+
+commonLabels:
+  team: frontend
+  project: yongchenglow
+  cost-center: personal
+  environment: review
+
+image:
+  repository: yongchenglow
+  pullPolicy: Always
+  tag: review
+
+service:
+  type: NodePort
+  port: 3000
+  nodePort: 31000 # Overridden by the review deployment workflow.
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: yongchenglow-review
+
+podAnnotations: {}
+
+env:
+  - name: NODE_ENV
+    value: production
+  - name: NEXT_PUBLIC_ENV
+    value: review
+
+resources:
+  limits:
+    cpu: 250m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+ingress:
+  enabled: false
+
+autoscaling:
+  enabled: false
+
+podDisruptionBudget:
+  enabled: false
+
+featureBranch:
+  enabled: true
+  portMappingNamespace: default


### PR DESCRIPTION
## Summary

- run quality checks and build a PR-specific image on pull request updates
- deploy isolated Helm review apps with Cloudflare DNS and tunnel routing
- tear down Kubernetes, Cloudflare, port allocation, and GitHub deployment state when a PR closes
- keep forked PRs away from deployment credentials and avoid duplicate branch push builds

## Review app lifecycle

- URL: https://pr-{number}-review.yongchenglow.com
- deploy events: opened, synchronize, reopened
- teardown event: closed

## Validation

- actionlint on all new workflows
- Helm lint with a representative PR image tag and NodePort
- rendered Kubernetes manifest client-side dry run
- git diff --check