### PR TITLE
feat: use hardened bun images

### DIFF
--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -58,6 +58,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Log in to Docker Hardened Images registry
+        uses: docker/login-action@v4
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DHI_REGISTRY_USERNAME }}
+          password: ${{ secrets.DHI_REGISTRY_PASSWORD }}
+
       - name: Log in to Container Registry
         if: inputs.push
         uses: docker/login-action@v4
@@ -109,6 +116,12 @@ jobs:
         id: package-version
         run: echo "VERSION=$(jq -r '.version // "0.0.0"' package.json)" >> $GITHUB_OUTPUT
 
+      - name: Determine DHI Bun series tag
+        id: dhi-bun-tag
+        run: |
+          DHI_BUN_TAG=$(echo "${{ inputs.bun_version }}" | cut -d. -f1,2)
+          echo "tag=${DHI_BUN_TAG}" >> "$GITHUB_OUTPUT"
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
         with:
@@ -118,6 +131,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             BUN_VERSION=${{ inputs.bun_version }}
+            DHI_BUN_TAG=${{ steps.dhi-bun-tag.outputs.tag }}
             BUILD_DATE=${{ github.event.head_commit.timestamp }}
             REVISION=${{ github.sha }}
             VERSION=${{ steps.package-version.outputs.VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-# Build arguments for versioning and metadata
-# BUN_VERSION is passed from CI (reads from package.json packageManager).
-# The default keeps `docker build` working without --build-arg; keep it in sync
-# with the `packageManager` field in package.json.
+# BUN_VERSION is extracted from package.json (packageManager) by CI and remains
+# a supported build argument. DHI publishes Bun 1.4 under the series tag below
+# rather than the repository's exact package-manager patch version.
 ARG BUN_VERSION=1.4.2
+ARG DHI_BUN_TAG=1.4
 
 # Stage 1: Builder
-FROM oven/bun:${BUN_VERSION}-alpine AS builder
+FROM dhi.io/bun:${DHI_BUN_TAG}-debian-dev AS builder
 WORKDIR /app
 
 # Install all dependencies including dev dependencies for build
@@ -19,10 +19,12 @@ COPY . .
 RUN bun run build
 
 # Stage 2: Runner
-FROM oven/bun:${BUN_VERSION}-alpine AS runner
+FROM dhi.io/bun:${DHI_BUN_TAG}-debian AS runner
 
-# Metadata arguments
+# Metadata arguments. BUN_VERSION is redeclared because an ARG set before the
+# first FROM goes out of scope inside a build stage.
 ARG BUN_VERSION
+ARG DHI_BUN_TAG
 ARG BUILD_DATE
 ARG REVISION
 ARG VERSION
@@ -35,36 +37,26 @@ LABEL org.opencontainers.image.created="${BUILD_DATE}" \
       org.opencontainers.image.revision="${REVISION}" \
       org.opencontainers.image.title="Yong Cheng Low" \
       org.opencontainers.image.description="Personal website built with Next.js" \
-      org.opencontainers.image.base.name="oven/bun:${BUN_VERSION}-alpine"
-
-# Patch openssl ahead of the upstream base image. oven/bun:${BUN_VERSION}-alpine
-# currently ships libcrypto3/libssl3 3.5.7-r0, which Trivy flags as HIGH under
-# CVE-2026-14456; 3.5.8-r0 carries the fix. Drop this once upstream rebuilds.
-RUN apk upgrade --no-cache libcrypto3 libssl3
+      org.opencontainers.image.base.name="dhi.io/bun:${DHI_BUN_TAG}-debian"
 
 WORKDIR /app
 
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
-# The oven/bun image already provides a non-root `bun` user (uid/gid 1000)
-
 # Copy necessary files from builder
-COPY --from=builder /app/public ./public
-COPY --from=builder --chown=bun:bun /app/.next/standalone ./
-COPY --from=builder --chown=bun:bun /app/.next/static ./.next/static
+COPY --from=builder --chown=65532:65532 /app/public ./public
+COPY --from=builder --chown=65532:65532 /app/.next/standalone ./
+COPY --from=builder --chown=65532:65532 /app/.next/static ./.next/static
 
-USER bun
+# DHI runtime images run as the nonroot user (UID 65532) and intentionally do
+# not include a shell or package manager.
+USER 65532:65532
 
 EXPOSE 3000
 
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
-
-# Probe with the Bun runtime that is already in the image, so the runner stage
-# stays free of curl/wget. A non-2xx response exits non-zero and marks unhealthy.
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD bun -e 'fetch("http://127.0.0.1:"+(process.env.PORT??3000)+"/").then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))'
 
 # Start the application on the Bun runtime
 CMD ["bun", "server.js"]

--- a/helm/nextjs-app/README.md
+++ b/helm/nextjs-app/README.md
@@ -13,12 +13,18 @@ This Helm chart deploys the Next.js application to Kubernetes.
 ### 1. Build and Push Docker Image
 
 ```bash
+# Authenticate before pulling the Docker Hardened Images base images
+docker login dhi.io
+
 # Build the image
 docker build -t your-registry/nextjs-frontend-template:latest .
 
 # Push to your registry
 docker push your-registry/nextjs-frontend-template:latest
 ```
+
+The reusable Docker workflow requires `DHI_REGISTRY_USERNAME` and
+`DHI_REGISTRY_PASSWORD` repository or organization secrets.
 
 ### 2. Install the Chart
 
@@ -162,7 +168,7 @@ All probes are configured to check the root path (`/`) on port 3000.
 
 The chart follows security best practices:
 
-- Runs as non-root user (uid: 1001)
+- Runs as Docker Hardened Images' non-root user (uid: 65532)
 - Drops all capabilities
 - Disables privilege escalation
 - Creates dedicated service account

--- a/helm/nextjs-app/values.yaml
+++ b/helm/nextjs-app/values.yaml
@@ -28,8 +28,8 @@ podAnnotations: {}
 
 podSecurityContext:
   runAsNonRoot: true
-  runAsUser: 1001
-  fsGroup: 1001
+  runAsUser: 65532
+  fsGroup: 65532
 
 securityContext:
   allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary

- authenticate the reusable Docker workflow with Docker Hardened Images
- derive the DHI Bun series tag from the package-managed Bun version
- build and run with the hardened Debian Bun images
- align container ownership and the Helm pod security context with DHI UID/GID 65532
- document local DHI login and required CI secrets

## Local verification

- bun test: 124 passed
- TypeScript: passed with Bun runtime
- Biome lint: passed
- Knip: passed (two existing configuration hints)
- Actionlint: passed with existing SC2086 findings ignored
- Helm lint and production template render: passed; rendered UID/GID 65532
- Authenticated pulls of dhi.io/bun:1.4-debian-dev and dhi.io/bun:1.4-debian: passed
- Docker build: DHI dependency install and complete Next.js production build passed; final layer assembly was interrupted when the host disk filled and OrbStack's Docker filesystem became read-only

## Configuration

Add DHI_REGISTRY_USERNAME and DHI_REGISTRY_PASSWORD as repository or organization secrets before running the deployment workflow.
